### PR TITLE
Correct a package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Building
 --------
 
 Make sure you install libcif++ first before building. You will also need
-to install [libcfp](https://github.com/mhekkel/libcfp).
+to install [libmcfp](https://github.com/mhekkel/libmcfp).
 
 After that, building should be as easy as typing:
 


### PR DESCRIPTION
This pull request includes a minor update to the `README.md` file. The change updates the library name in the installation instructions from `libcfp` to `libmcfp` to reflect the correct dependency.
(Probably, it's former name?)